### PR TITLE
added include unistd.h to libs/toolbox/src/utility_Math.cpp in order …

### DIFF
--- a/code/libs/toolbox/src/utility_Math.cpp
+++ b/code/libs/toolbox/src/utility_Math.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 #include <fcntl.h>
-
+#include <unistd.h>
 
 #include "Exception.h"
 


### PR DESCRIPTION
…to avoid `error: ‘read’ was not declared in this scope`